### PR TITLE
fix: Bracket placement in guard clause

### DIFF
--- a/underflipper.py
+++ b/underflipper.py
@@ -173,7 +173,7 @@ def process_eight(page_idx, card_pos, is_front):
         card_x_pos = card_no % 4
         card_y_pos = 0 if is_front else 1
         if ((len(card_pos) - 1) < page_offset
-                or len(card_pos[page_offset]) - 1) < card_x_pos:
+                or len(card_pos[page_offset]) - 1 < card_x_pos):
             return
         source_rect = Rect(card_pos[page_offset][card_x_pos],
                            UPPER_CARD_Y0 + card_y_pos * CARD_Y_OFFSET,


### PR DESCRIPTION
The check in `process_eight` protects against out of bound issues, however the closing bracket is placed in the wrong position. What this means is if you run the script with a Warband with the number of units equal to a boundry condition (e.g. Mollog's Mob with 4) you will get an index out of bounds exception.

This PR fixes the bracket palcement and allows successful processing of warbands with those number of units.